### PR TITLE
Updated thresholds to be consistent

### DIFF
--- a/lab-session-4/DeepLens-final-Lab-4.ipynb
+++ b/lab-session-4/DeepLens-final-Lab-4.ipynb
@@ -152,7 +152,7 @@
     "        Message: 'Your DeepLens device just identified a Hot Dog. Congratulations!',\n",
     "        PhoneNumber: phone_number\n",
     "    };\n",
-    "    if (event.Hotdog > 0.50)\n",
+    "    if (event.Hotdog > 0.90)\n",
     "        SNS.publish(params, callback);\n",
     "};"
    ]
@@ -229,7 +229,7 @@
     {
      "data": {
       "text/plain": [
-       "{'Hotdog': 0.6875}"
+       "{'Hotdog': 0.9185}"
       ]
      },
      "execution_count": 2,
@@ -239,7 +239,7 @@
    ],
    "source": [
     "{\n",
-    "    \"Hotdog\": 0.6875\n",
+    "    \"Hotdog\": 0.9185\n",
     "}"
    ]
   },


### PR DESCRIPTION
The thresholds were different between email/SMS, so aligning them to be consistent and updating the demo to be over the .90 threshold.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
